### PR TITLE
Add option to send test message without identifier

### DIFF
--- a/test/k6/inc/common.js
+++ b/test/k6/inc/common.js
@@ -189,20 +189,16 @@ export function params(client) {
     return params;
 }
 
-export function postMessage(url, payload) {
+export function postMessage(url, payload, includeIdentifier = true) {
     var now = new Date(Date.now());
 
     var msgId = "urn:uuid:" + uuid.v4();
 
     var timestamp = now.toISOString().replace("Z", "");
-    var timestamp = timestamp.substr(0, 19) + "+00:00";
+    var timestamp = timestamp.substring(0, 19) + "+00:00";
 
     var fhirPayload = {
         "resourceType": "DocumentReference",
-        "masterIdentifier": {
-            "system": "urn:ietf:rfc:3986",
-            "value": msgId
-        },
         "status": "current",
         "date": timestamp,
         "content": [
@@ -214,6 +210,14 @@ export function postMessage(url, payload) {
             }
         ]
     };
+
+    if (includeIdentifier) {
+        fhirPayload["masterIdentifier"] = {
+            "system": "urn:ietf:rfc:3986",
+            "value": msgId
+        };
+        console.log("Generated identifier: " + msgId);
+    }
 
     console.log("Payload:= " + payload);
     console.log("[ERX_ENV= " + environment + "] POST " + url);
@@ -237,11 +241,11 @@ export function postMessage(url, payload) {
 export function submitMessage(url, example) {
     console.log("Request: " + example.name + ' [' + example.version + '] ' + example.purpose);
     var payload = Hl7v2Encoded(example.message); // Returns Base64 encoded hl7v2 message
-    return postMessage(url, payload);
+    return postMessage(url, payload, example.includeIdentifier);
 }
 
 export function submitHL7MessageBase64(url, b64Payload) {
-    return postMessage(url, b64Payload);
+    return postMessage(url, b64Payload, true);
 }
 
 function encode(hl7Message) {

--- a/test/k6/inc/examples/Claim.js
+++ b/test/k6/inc/examples/Claim.js
@@ -44,6 +44,7 @@ export let Claim = [
         name: "TACTDU_0104_REQUEST-20334 (encrypted)",
         purpose: "Adjudicate a Dispense Claim request message (Encrypted)",
         version: "PNet-R70",
+        includeIdentifier: false,
         message:
             "MSH|^~\\&|123456|123456|MOH|PP|${{ timestamp }}||ZPN|20334|P|2.1|\r" +
             "ZZZ|TAC||020618|P1|nnnnnnnnnn|||\r" +
@@ -86,6 +87,7 @@ export let Claim = [
         name: "TACTDU_01_REQUEST-324232",
         purpose: "Adjudicate a Dispense Claim request message",
         version: "PNet-R70",
+        includeIdentifier: false,
         message:
             "MSH|^~\\&|DESKTOP|PHARMACY|PNP|ERXPP|${{ timestamp }}|userID:192.168.0.1|ZPN|324232|P|2.1||\r" +
             "ZCA|1|70|01|AR|05|\r" +
@@ -128,6 +130,7 @@ export let Claim = [
         name: "TACTDU_11_REQUEST-319233-1",
         purpose: "Adjudicate a Dispense Claim Reversal request message",
         version: "PNet-R70",
+        includeIdentifier: false,
         message:
             "MSH|^~\\&|123456|123456||ERXPP|${{ timestamp }}|userID:192.168.0.1|ZPN|319233|P|2.1||\r" +
             "ZZZ|TAC||319233|P1|nnnnnnnnnn|||||ZZZ1^\r" +
@@ -173,6 +176,7 @@ export let Claim = [
         name: "TACTDUTRP_01_REQUEST-324232",
         purpose: "Adjudicate a Dispense Claim TAC/TDU/TRP request message",
         version: "PNet-R70",
+        includeIdentifier: false,
         message:
             "MSH|^~\\&|DESKTOP|PHARMACY|PNP|ERXPP|${{ timestamp }}|userID:192.168.0.1|ZPN|324232|P|2.1||\r" +
             "ZCA|1|70|01|AR|05|\r" +

--- a/test/k6/inc/examples/Consent.js
+++ b/test/k6/inc/examples/Consent.js
@@ -24,5 +24,17 @@ export let Consent = [
             "ZCA||70|00|AR|05|\r" +
             "ZCB|BC00000I10|140802|998015\r" +
             "ZCC||||||||||000nnnnnnnnnn|\r\r"
+    },
+    {
+        name: "TCP_00_REQUEST-998015",
+        purpose: "Patient Keyword Maintenance request message",
+        version: "PNet-R70",
+        includeIdentifier: false,
+        message:
+            "MSH|^~\\&|1234567|1234567||ERXPP|${{ timestamp }}|userID:192.168.0.1|ZPN|998015|P|2.1||\r" +
+            "ZZZ|TCP||998015|P1|nnnnnnnnnn||||KEYWORD|ZZZ1^\r" +
+            "ZCA||70|00|AR|05|\r" +
+            "ZCB|BC00000I10|140802|998015\r" +
+            "ZCC||||||||||000nnnnnnnnnn|\r\r"
     }
 ];

--- a/test/k6/inc/examples/Location.js
+++ b/test/k6/inc/examples/Location.js
@@ -24,5 +24,17 @@ export let Location = [
             "ZCB|MDA|120113|1111\r" + 
             "ZPL|QAERXPP||||||||||||||MM\r" + 
             "ZZZ|TIL||1111|P1|nnnnnnnnnn|||||ZZZ1\r\r"
+    },
+    {
+        name: "TIL_00_REQUEST-1111",
+        purpose: "Get Location Details request message",
+        version: "PNet-R70",
+        includeIdentifier: false,
+        message:
+            "MSH|^~\\&|1234567|1234567||EMRMD|${{ timestamp }}||ZPN|1111|P|2.1||\r" +
+            "ZCA||70|00|MA|01|\r" + 
+            "ZCB|MDA|120113|1111\r" + 
+            "ZPL|QAERXPP||||||||||||||MM\r" + 
+            "ZZZ|TIL||1111|P1|nnnnnnnnnn|||||ZZZ1\r\r"
     }
 ];

--- a/test/k6/inc/examples/Medication.js
+++ b/test/k6/inc/examples/Medication.js
@@ -43,6 +43,7 @@ export let Medication = [
         name: "TDR_50_REQUEST - 149966",
         purpose: "Drug Monograph Information request message",
         version: "PNet-R70",
+        includeIdentifier: false,
         message:
             "MSH|^~\\&|1234567|1234567||ERXPP|${{ timestamp }}|userID:192.168.0.1|ZPN|149966|P|2.1||\r" +
             "ZZZ|TDR||149966|P1|nnnnnnnnnn|||||ZZZ1^\r" +

--- a/test/k6/inc/examples/MedicationDispense.js
+++ b/test/k6/inc/examples/MedicationDispense.js
@@ -44,6 +44,7 @@ export let MedicationDispense = [
         name: "TMU_01_REQUEST - 119908",
         purpose: "Medication Update request message",
         version: "PNet-R70",
+        includeIdentifier: false,
         message:
             "MSH|^~\\&|DESKTOP|EMR|DISMEDUPDATE|EMRMD|${{ timestamp }}|userID:192.168.0.1|ZPN|119908|P|2.1||\r" +
             "ZZZ|TMU||119908|91|nnnnnnnnnn|||||ZZZ1^\r" +

--- a/test/k6/inc/examples/MedicationRequest.js
+++ b/test/k6/inc/examples/MedicationRequest.js
@@ -42,6 +42,7 @@ export let MedicationRequest = [
         name: "TRX_X0_REQUEST - 125",
         purpose: "Retrieve Patient Prescription request message",
         version: "PNet-R70",
+        includeIdentifier: false,
         message:
             "MSH|^~\\&|1234567|1234567||ERXPP|${{ timestamp }}|userID:192.168.0.1|ZPN|125|P|2.1||\r" +
             "ZCA||70|X0|M1|04|\r" +
@@ -78,6 +79,7 @@ export let MedicationRequest = [
         name: "TRX_X1_REQUEST - 195233",
         purpose: "Record a Prescription request message",
         version: "PNet-R70",
+        includeIdentifier: false,
         message:
             "MSH|^~\\&|1234567|1234567|1234567|ERXPP|${{ timestamp }}|userID:192.168.0.1|ZPN|195233|P|2.1||\r" +
             "ZCA|1|70|X1|AR|05|123456\r" +
@@ -114,6 +116,7 @@ export let MedicationRequest = [
         name: "TRX_X3_REQUEST - 100004",
         purpose: "Adapt a Prescription request message",
         version: "PNet-R70",
+        includeIdentifier: false,
         message:
             "MSH|^~\\&|DESKTOP|BC01111111|DESKTOP|ERXPP|${{ timestamp }}|userID:192.168.0.1|ZPN|100004|P|2.1|123456|\r" +
             "ZCA|123456|70|X3|AR|05|123456\r" +

--- a/test/k6/inc/examples/MedicationStatement.js
+++ b/test/k6/inc/examples/MedicationStatement.js
@@ -45,6 +45,7 @@ export let MedicationStatement = [
         name: "TDUTRR_00_REQUEST-332214",
         purpose: "DUE Inquiry TDU/TRR request message",
         version: "PNet-R3",
+        includeIdentifier: false,
         message:
             "MSH|^~\\&|1234567|1234567||ERXPP||userID:192.168.0.1|ZPN|332214|P|2.1||\r" +
             "ZZZ|TRR||332214|P1|nnnnnnnnnn||||\r" +
@@ -83,6 +84,7 @@ export let MedicationStatement = [
         name: "TRP_00_REQUEST - R3",
         purpose: "Patient Profile Request request message (NEXT initial request)",
         version: "PNet-R3",
+        includeIdentifier: false,
         message:
             "MSH|^~\\&|XXXXXXXXXXXXXXX|NA|PNP|PP||userID:192.168.0.1|ZPN|101159|P|2.1||\r" +
             "ZZZ|TRP||101159|P1|nnnnnnnnnn||||\r" +
@@ -111,6 +113,7 @@ export let MedicationStatement = [
         name: "TRP_00_REQUEST - 248875",
         purpose: "Patient Profile Request message",
         version: "PNet-R70",
+        includeIdentifier: false,
         message:
             "MSH|^~\\&|1234567|1234567||EMRMD|${{ timestamp }}|userID:192.168.0.1|ZPN|248875|P|2.1||\r" +
             "ZZZ|TRP||248876|91|nnnnnnnnnn|||||ZZZ1^\r" +
@@ -144,6 +147,7 @@ export let MedicationStatement = [
         name: "TRR_00_REQUEST-235348",
         purpose: "Patient Profile Most Recent Only Request message",
         version: "PNet-R70",
+        includeIdentifier: false,
         message:
             "MSH|^~\\&|1234567|1234567||ERXPP|${{ timestamp }}|userID:192.168.0.1|ZPN|235348|P|2.1||\r" +
             "ZZZ|TRR||235348|P1|nnnnnnnnnn|||||ZZZ1^\r" +

--- a/test/k6/inc/examples/Patient.js
+++ b/test/k6/inc/examples/Patient.js
@@ -41,6 +41,7 @@ export let Patient = [
         name: " TPH_00_REQUEST - 62028",
         purpose: "Patient PHN Assignment request message",
         version: "PNet-R70",
+        includeIdentifier: false,
         message:
             "MSH|^~\\&|1234567|1234567||ERXPP|${{ timestamp }}|userID:192.168.0.1|ZPN|62028|P|2.1||\r" +
             "ZZZ|TPH||62028|P1|nnnnnnnnnn|||||ZZZ1^\r" +

--- a/test/k6/inc/examples/Practitioner.js
+++ b/test/k6/inc/examples/Practitioner.js
@@ -24,5 +24,17 @@ export let Practitioner = [
             "ZCA||70|00|AR|05|\r" +
             "ZCB|BC00000I10|140819|449126\r" +
             "ZPH|P1|12615|||||||||||||||\r\r"
+    },
+    {
+        name: "TIP_00_REQUEST - R70",
+        purpose: "Prescriber Identification request message",
+        version: "PNet-R70",
+        includeIdentifier: false,
+        message:
+            "MSH|^~\\&|1234567|1234567||ERXPP|${{ timestamp }}|userID:192.168.0.1|ZPN|449126|P|2.1||\r" +
+            "ZZZ|TIP||449126|P1|nnnnnnnnnn|||||ZZZ1^\r" +
+            "ZCA||70|00|AR|05|\r" +
+            "ZCB|BC00000I10|140819|449126\r" +
+            "ZPH|P1|12615|||||||||||||||\r\r"
     }
 ];


### PR DESCRIPTION
Considering the recent bug fix around api calls that are made without a master identifier, I have updated the test cases and the k6 module to run tests both with and without a master identifier.
I have also updated the documentation in the wiki to reflect this.