### PR TITLE
No downtime probes

### DIFF
--- a/tools/helm/ppmservice/templates/deployment.yaml
+++ b/tools/helm/ppmservice/templates/deployment.yaml
@@ -62,7 +62,7 @@ spec:
                   key: {{ $key }}
             {{- end }}                 
           startupProbe:
-            periodSeconds: 60
+            periodSeconds: 120
             timeoutSeconds: 10
             successThreshold: 1
             failureThreshold: 10

--- a/tools/helm/ppmservice/templates/deployment.yaml
+++ b/tools/helm/ppmservice/templates/deployment.yaml
@@ -70,12 +70,15 @@ spec:
               command:
                 - './health-check.sh'
           readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /health
+              port: {{ .Values.Application.Port }}
+              scheme: HTTP
+            initialDelaySeconds: 10
             periodSeconds: 20
-            timeoutSeconds: 10
-            successThreshold: 3
-            exec:
-              command:
-                - './health-check.sh'
+            successThreshold: 1
+            timeoutSeconds: 4
           lifecycle:
             preStop:
               exec:

--- a/tools/helm/ppmservice/templates/deployment.yaml
+++ b/tools/helm/ppmservice/templates/deployment.yaml
@@ -62,7 +62,7 @@ spec:
                   key: {{ $key }}
             {{- end }}                 
           startupProbe:
-            periodSeconds: 120
+            periodSeconds: 60
             timeoutSeconds: 10
             successThreshold: 1
             failureThreshold: 10


### PR DESCRIPTION
This PR is required to revert the change that introduce a Health Check in a readiness probe that submitted a full authentication request and request to PharmaNet endpoint. These were causing issues for the downstream systems so will be removed. The start up probe will be kept to ensure the application is able to receive requests before it's pod receives them.