### PR TITLE
Redhat action CLI tools

### DIFF
--- a/.github/workflows/build-claimservice.yml
+++ b/.github/workflows/build-claimservice.yml
@@ -24,6 +24,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      # Set up the OpenShift CLI tools required. Note, these used to be included with earlier runner images but that is no longer guaranteed so they must be installed.
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          source: "mirror"
+          kam: "latest"
+          oc: "4"
+      
       - name: "Checkout source"
         uses: actions/checkout@v3
 
@@ -40,7 +48,7 @@ jobs:
           docker build -f $GITHUB_WORKSPACE/Services/$APP/src/Dockerfile $RUNNER_TEMP -t $imageName:dev
 
       - name: OpenShift Silver Login
-        uses: redhat-actions/oc-login@v1.1
+        uses: redhat-actions/oc-login@v1.3
         with:
           openshift_server_url: ${{ secrets.SILVER_URI }}
           openshift_token: ${{ secrets.SILVER_TOKEN }}

--- a/.github/workflows/build-consentservice.yml
+++ b/.github/workflows/build-consentservice.yml
@@ -24,6 +24,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      # Set up the OpenShift CLI tools required. Note, these used to be included with earlier runner images but that is no longer guaranteed so they must be installed.
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          source: "mirror"
+          kam: "latest"
+          oc: "4"
+      
       - name: "Checkout source"
         uses: actions/checkout@v3
 
@@ -40,7 +48,7 @@ jobs:
           docker build -f $GITHUB_WORKSPACE/Services/$APP/src/Dockerfile $RUNNER_TEMP -t $imageName:dev
 
       - name: OpenShift Silver Login
-        uses: redhat-actions/oc-login@v1.1
+        uses: redhat-actions/oc-login@v1.3
         with:
           openshift_server_url: ${{ secrets.SILVER_URI }}
           openshift_token: ${{ secrets.SILVER_TOKEN }}

--- a/.github/workflows/build-locationservice.yml
+++ b/.github/workflows/build-locationservice.yml
@@ -24,6 +24,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      # Set up the OpenShift CLI tools required. Note, these used to be included with earlier runner images but that is no longer guaranteed so they must be installed.
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          source: "mirror"
+          kam: "latest"
+          oc: "4"
+      
       - name: "Checkout source"
         uses: actions/checkout@v3
 
@@ -40,7 +48,7 @@ jobs:
           docker build -f $GITHUB_WORKSPACE/Services/$APP/src/Dockerfile $RUNNER_TEMP -t $imageName:dev
 
       - name: OpenShift Silver Login
-        uses: redhat-actions/oc-login@v1.1
+        uses: redhat-actions/oc-login@v1.3
         with:
           openshift_server_url: ${{ secrets.SILVER_URI }}
           openshift_token: ${{ secrets.SILVER_TOKEN }}

--- a/.github/workflows/build-medicationdispenseservice.yml
+++ b/.github/workflows/build-medicationdispenseservice.yml
@@ -24,6 +24,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      # Set up the OpenShift CLI tools required. Note, these used to be included with earlier runner images but that is no longer guaranteed so they must be installed.
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          source: "mirror"
+          kam: "latest"
+          oc: "4"
+      
       - name: "Checkout source"
         uses: actions/checkout@v3
 
@@ -40,7 +48,7 @@ jobs:
           docker build -f $GITHUB_WORKSPACE/Services/$APP/src/Dockerfile $RUNNER_TEMP -t $imageName:dev
 
       - name: OpenShift Silver Login
-        uses: redhat-actions/oc-login@v1.1
+        uses: redhat-actions/oc-login@v1.3
         with:
           openshift_server_url: ${{ secrets.SILVER_URI }}
           openshift_token: ${{ secrets.SILVER_TOKEN }}

--- a/.github/workflows/build-medicationrequestservice.yml
+++ b/.github/workflows/build-medicationrequestservice.yml
@@ -24,6 +24,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      # Set up the OpenShift CLI tools required. Note, these used to be included with earlier runner images but that is no longer guaranteed so they must be installed.
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          source: "mirror"
+          kam: "latest"
+          oc: "4"
+      
       - name: "Checkout source"
         uses: actions/checkout@v3
 
@@ -40,7 +48,7 @@ jobs:
           docker build -f $GITHUB_WORKSPACE/Services/$APP/src/Dockerfile $RUNNER_TEMP -t $imageName:dev
 
       - name: OpenShift Silver Login
-        uses: redhat-actions/oc-login@v1.1
+        uses: redhat-actions/oc-login@v1.3
         with:
           openshift_server_url: ${{ secrets.SILVER_URI }}
           openshift_token: ${{ secrets.SILVER_TOKEN }}

--- a/.github/workflows/build-medicationservice.yml
+++ b/.github/workflows/build-medicationservice.yml
@@ -24,6 +24,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      # Set up the OpenShift CLI tools required. Note, these used to be included with earlier runner images but that is no longer guaranteed so they must be installed.
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          source: "mirror"
+          kam: "latest"
+          oc: "4"
+      
       - name: "Checkout source"
         uses: actions/checkout@v3
 
@@ -40,7 +48,7 @@ jobs:
           docker build -f $GITHUB_WORKSPACE/Services/$APP/src/Dockerfile $RUNNER_TEMP -t $imageName:dev
 
       - name: OpenShift Silver Login
-        uses: redhat-actions/oc-login@v1.1
+        uses: redhat-actions/oc-login@v1.3
         with:
           openshift_server_url: ${{ secrets.SILVER_URI }}
           openshift_token: ${{ secrets.SILVER_TOKEN }}

--- a/.github/workflows/build-medicationstatementservice.yml
+++ b/.github/workflows/build-medicationstatementservice.yml
@@ -24,6 +24,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      # Set up the OpenShift CLI tools required. Note, these used to be included with earlier runner images but that is no longer guaranteed so they must be installed.
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          source: "mirror"
+          kam: "latest"
+          oc: "4"
+      
       - name: "Checkout source"
         uses: actions/checkout@v3
 
@@ -40,7 +48,7 @@ jobs:
           docker build -f $GITHUB_WORKSPACE/Services/$APP/src/Dockerfile $RUNNER_TEMP -t $imageName:dev
 
       - name: OpenShift Silver Login
-        uses: redhat-actions/oc-login@v1.1
+        uses: redhat-actions/oc-login@v1.3
         with:
           openshift_server_url: ${{ secrets.SILVER_URI }}
           openshift_token: ${{ secrets.SILVER_TOKEN }}

--- a/.github/workflows/build-patientservice.yml
+++ b/.github/workflows/build-patientservice.yml
@@ -24,6 +24,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      # Set up the OpenShift CLI tools required. Note, these used to be included with earlier runner images but that is no longer guaranteed so they must be installed.
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          source: "mirror"
+          kam: "latest"
+          oc: "4"
+      
       - name: "Checkout source"
         uses: actions/checkout@v3
 
@@ -40,7 +48,7 @@ jobs:
           docker build -f $GITHUB_WORKSPACE/Services/$APP/src/Dockerfile $RUNNER_TEMP -t $imageName:dev
 
       - name: OpenShift Silver Login
-        uses: redhat-actions/oc-login@v1.1
+        uses: redhat-actions/oc-login@v1.3
         with:
           openshift_server_url: ${{ secrets.SILVER_URI }}
           openshift_token: ${{ secrets.SILVER_TOKEN }}

--- a/.github/workflows/build-practitionerservice.yml
+++ b/.github/workflows/build-practitionerservice.yml
@@ -22,8 +22,15 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          source: "mirror"
+          kam: "latest"
+          oc: "4"
+          
       - name: "Checkout source"
         uses: actions/checkout@v3
 

--- a/.github/workflows/build-practitionerservice.yml
+++ b/.github/workflows/build-practitionerservice.yml
@@ -40,7 +40,7 @@ jobs:
           docker build -f $GITHUB_WORKSPACE/Services/$APP/src/Dockerfile $RUNNER_TEMP -t $imageName:dev
 
       - name: OpenShift Silver Login
-        uses: redhat-actions/oc-login@v1.1
+        uses: redhat-actions/oc-login@v1.3
         with:
           openshift_server_url: ${{ secrets.SILVER_URI }}
           openshift_token: ${{ secrets.SILVER_TOKEN }}

--- a/.github/workflows/build-practitionerservice.yml
+++ b/.github/workflows/build-practitionerservice.yml
@@ -24,13 +24,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      # Set up the OpenShift CLI tools required. Note, these used to be included with earlier runner images but that is no longer guaranteed so they must be installed.
       - name: Install CLI tools from OpenShift Mirror
         uses: redhat-actions/openshift-tools-installer@v1
         with:
           source: "mirror"
           kam: "latest"
           oc: "4"
-          
+      
       - name: "Checkout source"
         uses: actions/checkout@v3
 

--- a/.github/workflows/build-practitionerservice.yml
+++ b/.github/workflows/build-practitionerservice.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: "Checkout source"
         uses: actions/checkout@v3

--- a/.github/workflows/deploy-to-gold.yml
+++ b/.github/workflows/deploy-to-gold.yml
@@ -46,6 +46,14 @@ jobs:
       matrix: ${{ fromJSON(needs.prepare-matrix.outputs.matrix) }}
 
     steps:
+      # Set up the OpenShift CLI tools required. Note, these used to be included with earlier runner images but that is no longer guaranteed so they must be installed.
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          source: "mirror"
+          kam: "latest"
+          oc: "4"
+      
       - name: "Checkout source"
         uses: actions/checkout@v3
 
@@ -62,7 +70,7 @@ jobs:
           docker build -f $GITHUB_WORKSPACE/Services/${{ matrix.service }}/src/Dockerfile $RUNNER_TEMP -t $imageName:${{ inputs.environment }}
 
       - name: OpenShift Gold Login
-        uses: redhat-actions/oc-login@v1.1
+        uses: redhat-actions/oc-login@v1.3
         with:
           openshift_server_url: ${{ secrets.GOLD_URI }}
           openshift_token: ${{ secrets.GOLD_TOKEN }}
@@ -75,7 +83,7 @@ jobs:
           docker push $imageName:${{ inputs.environment }}
 
       - name: OpenShift Gold DR Login
-        uses: redhat-actions/oc-login@v1.1
+        uses: redhat-actions/oc-login@v1.3
         with:
           openshift_server_url: ${{ secrets.GOLDDR_URI }}
           openshift_token: ${{ secrets.GOLDDR_TOKEN }}

--- a/.github/workflows/deploy-to-silver.yml
+++ b/.github/workflows/deploy-to-silver.yml
@@ -49,6 +49,14 @@ jobs:
       matrix: ${{ fromJSON(needs.prepare-matrix.outputs.matrix) }}
 
     steps:
+      # Set up the OpenShift CLI tools required. Note, these used to be included with earlier runner images but that is no longer guaranteed so they must be installed.
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          source: "mirror"
+          kam: "latest"
+          oc: "4"
+      
       - name: "Checkout source"
         uses: actions/checkout@v3
 
@@ -65,7 +73,7 @@ jobs:
           docker build -f $GITHUB_WORKSPACE/Services/${{ matrix.service }}/src/Dockerfile $RUNNER_TEMP -t $imageName:${{ inputs.environment }}
 
       - name: OpenShift Silver Login
-        uses: redhat-actions/oc-login@v1.1
+        uses: redhat-actions/oc-login@v1.3
         with:
           openshift_server_url: ${{ secrets.SILVER_URI }}
           openshift_token: ${{ secrets.SILVER_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,9 +50,17 @@ jobs:
       matrix: ${{ fromJSON(needs.prepare-matrix.outputs.matrix) }}
 
     steps:
+      # Set up the OpenShift CLI tools required. Note, these used to be included with earlier runner images but that is no longer guaranteed so they must be installed.
+      - name: Install CLI tools from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          source: "mirror"
+          kam: "latest"
+          oc: "4"
+      
       - name: OpenShift Gold Login
         if: inputs.service == 'all' || inputs.service == matrix.service
-        uses: redhat-actions/oc-login@v1.1
+        uses: redhat-actions/oc-login@v1.3
         with:
           openshift_server_url: ${{ secrets.GOLD_URI }}
           openshift_token: ${{ secrets.GOLD_TOKEN }}
@@ -69,7 +77,7 @@ jobs:
 
       - name: OpenShift Gold DR Login
         if: inputs.service == 'all' || inputs.service == matrix.service
-        uses: redhat-actions/oc-login@v1.1
+        uses: redhat-actions/oc-login@v1.3
         with:
           openshift_server_url: ${{ secrets.GOLDDR_URI }}
           openshift_token: ${{ secrets.GOLDDR_TOKEN }}


### PR DESCRIPTION
Redhat action CLI tools must be added to the runner image as they are no longer included with latest images of Ubuntu. Fixed by adding CLI tools using installer as detailed in https://github.com/redhat-actions/openshift-tools-installer.

Redhat action version was also updated