### PR TITLE
BCMOHAM-23974 pharmanet api error: Allowing TAC/TDU 04 messages

### DIFF
--- a/Services/ClaimService/src/appsettings.json
+++ b/Services/ClaimService/src/appsettings.json
@@ -79,7 +79,7 @@
             },
             {
                 "Name": "TACTDU_04_REQUEST-*",
-                "Purpose": "Adjudicate a Dispense Request - Specify different recipient",
+                "Purpose": "Adjudicate a Dispense Request - adjust, reverse, or resubmit an existing claim",
                 "MessageType": "ZPN",
                 "Scope": "system/Claim.write system/*.write",
                 "MessageSegments": [

--- a/Services/ClaimService/src/appsettings.json
+++ b/Services/ClaimService/src/appsettings.json
@@ -78,6 +78,44 @@
                 ]
             },
             {
+                "Name": "TACTDU_04_REQUEST-*",
+                "Purpose": "Adjudicate a Dispense Request - Specify different recipient",
+                "MessageType": "ZPN",
+                "Scope": "system/Claim.write system/*.write",
+                "MessageSegments": [
+                    {
+                        "SegmentName": "ZZZ",
+                        "SegmentFields": [
+                            {
+                                "Index": "1",
+                                "Value": "TAC",
+                                "ValueMatchType": "Exact"
+                            }
+                        ]
+                    },
+                    {
+                        "SegmentName": "ZZZ",
+                        "SegmentFields": [
+                            {
+                                "Index": "1",
+                                "Value": "TDU",
+                                "ValueMatchType": "Exact"
+                            }
+                        ]
+                    },
+                    {
+                        "SegmentName": "ZCA",
+                        "SegmentFields": [
+                            {
+                                "Index": "3",
+                                "Value": "04",
+                                "ValueMatchType": "Exact"
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
                 "Name": "TACTDU_11_REQUEST-*",
                 "Purpose": "Adjudicate a Dispense Reversal Request",
                 "Scope": "system/Claim.write system/*.write",

--- a/test/k6/examples/dev/claim.js
+++ b/test/k6/examples/dev/claim.js
@@ -42,6 +42,20 @@ export const examples = [
             "ZZZ|TDU||319233|P1|nnnnnnnnnn|||||ZZZ1^\r"
     },
     {
+        name: "TACTDU_04_REQUEST-319234",
+        purpose: "Adjudicate a Dispense Claim adjust, reverse, or resubmit an existing claim",
+        version: "PNet-R70",
+        message:
+            "MSH|^~\\&|123456|123456||ERXPP|${{ timestamp }}|userID:192.168.0.1|ZPN|319234|P|2.1||\r" +
+            "ZCA|1|70|04|AR|05|\r" +
+            "ZCB|BC00000I10|140905|319234\r" +
+            "ZCC||||||||||000nnnnnnnnnn|\r" +
+            "ZCD|||N|319234||319234|2063735||100|7|91|nnnnnnnnnn|||||1486||222|||||nnnnnn|912351175\r" +
+            "ZPJ|ZPJ1^^^^^^|ZPJ2^^~ZPJ2^^~ZPJ2^^|ZPJ3^^|ZPJ4^Transaction Trace ID: 319234\r" +
+            "ZZZ|TAC||319234|P1|nnnnnnnnnn|||||ZZZ1^\r" +
+            "ZZZ|TDU||319234|P1|nnnnnnnnnn|||||ZZZ1^\r"
+    },
+    {
         name: "TACTDU_0104_REQUEST-20334 (encrypted)",
         purpose: "Adjudicate a Dispense Claim request message (Encrypted)",
         version: "PNet-R70",

--- a/test/k6/examples/prd/claim.js
+++ b/test/k6/examples/prd/claim.js
@@ -42,6 +42,20 @@ export const examples = [
             "ZZZ|TDU||319233|P1|nnnnnnnnnn|||||ZZZ1^\r"
     },
     {
+        name: "TACTDU_04_REQUEST-319234",
+        purpose: "Adjudicate a Dispense Claim adjust, reverse, or resubmit an existing claim",
+        version: "PNet-R70",
+        message:
+            "MSH|^~\\&|123456|123456||ERXPP|${{ timestamp }}|userID:192.168.0.1|ZPN|319234|P|2.1||\r" +
+            "ZCA|1|70|04|AR|05|\r" +
+            "ZCB|BC00000I10|140905|319234\r" +
+            "ZCC||||||||||000nnnnnnnnnn|\r" +
+            "ZCD|||N|319234||319234|2063735||100|7|91|nnnnnnnnnn|||||1486||222|||||nnnnnn|912351175\r" +
+            "ZPJ|ZPJ1^^^^^^|ZPJ2^^~ZPJ2^^~ZPJ2^^|ZPJ3^^|ZPJ4^Transaction Trace ID: 319234\r" +
+            "ZZZ|TAC||319234|P1|nnnnnnnnnn|||||ZZZ1^\r" +
+            "ZZZ|TDU||319234|P1|nnnnnnnnnn|||||ZZZ1^\r"
+    },
+    {
         name: "TACTDU_0104_REQUEST-20334 (encrypted)",
         purpose: "Adjudicate a Dispense Claim request message (Encrypted)",
         version: "PNet-R70",

--- a/test/k6/examples/tr1/claim.js
+++ b/test/k6/examples/tr1/claim.js
@@ -42,6 +42,20 @@ export const examples = [
             "ZZZ|TDU||319233|P1|nnnnnnnnnn|||||ZZZ1^\r"
     },
     {
+        name: "TACTDU_04_REQUEST-319234",
+        purpose: "Adjudicate a Dispense Claim adjust, reverse, or resubmit an existing claim",
+        version: "PNet-R70",
+        message:
+            "MSH|^~\\&|123456|123456||ERXPP|${{ timestamp }}|userID:192.168.0.1|ZPN|319234|P|2.1||\r" +
+            "ZCA|1|70|04|AR|05|\r" +
+            "ZCB|BC00000I10|140905|319234\r" +
+            "ZCC||||||||||000nnnnnnnnnn|\r" +
+            "ZCD|||N|319234||319234|2063735||100|7|91|nnnnnnnnnn|||||1486||222|||||nnnnnn|912351175\r" +
+            "ZPJ|ZPJ1^^^^^^|ZPJ2^^~ZPJ2^^~ZPJ2^^|ZPJ3^^|ZPJ4^Transaction Trace ID: 319234\r" +
+            "ZZZ|TAC||319234|P1|nnnnnnnnnn|||||ZZZ1^\r" +
+            "ZZZ|TDU||319234|P1|nnnnnnnnnn|||||ZZZ1^\r"
+    },
+    {
         name: "TACTDU_0104_REQUEST-20334 (encrypted)",
         purpose: "Adjudicate a Dispense Claim request message (Encrypted)",
         version: "PNet-R70",

--- a/test/k6/examples/vc1/claim.js
+++ b/test/k6/examples/vc1/claim.js
@@ -42,6 +42,20 @@ export const examples = [
             "ZZZ|TDU||319233|P1|nnnnnnnnnn|||||ZZZ1^\r"
     },
     {
+        name: "TACTDU_04_REQUEST-319234",
+        purpose: "Adjudicate a Dispense Claim adjust, reverse, or resubmit an existing claim",
+        version: "PNet-R70",
+        message:
+            "MSH|^~\\&|123456|123456||ERXPP|${{ timestamp }}|userID:192.168.0.1|ZPN|319234|P|2.1||\r" +
+            "ZCA|1|70|04|AR|05|\r" +
+            "ZCB|BC00000I10|140905|319234\r" +
+            "ZCC||||||||||000nnnnnnnnnn|\r" +
+            "ZCD|||N|319234||319234|2063735||100|7|91|nnnnnnnnnn|||||1486||222|||||nnnnnn|912351175\r" +
+            "ZPJ|ZPJ1^^^^^^|ZPJ2^^~ZPJ2^^~ZPJ2^^|ZPJ3^^|ZPJ4^Transaction Trace ID: 319234\r" +
+            "ZZZ|TAC||319234|P1|nnnnnnnnnn|||||ZZZ1^\r" +
+            "ZZZ|TDU||319234|P1|nnnnnnnnnn|||||ZZZ1^\r"
+    },
+    {
         name: "TACTDU_0104_REQUEST-20334 (encrypted)",
         purpose: "Adjudicate a Dispense Claim request message (Encrypted)",
         version: "PNet-R70",

--- a/test/k6/examples/vc2/claim.js
+++ b/test/k6/examples/vc2/claim.js
@@ -42,6 +42,20 @@ export const examples = [
             "ZZZ|TDU||319233|P1|nnnnnnnnnn|||||ZZZ1^\r"
     },
     {
+        name: "TACTDU_04_REQUEST-319234",
+        purpose: "Adjudicate a Dispense Claim adjust, reverse, or resubmit an existing claim",
+        version: "PNet-R70",
+        message:
+            "MSH|^~\\&|123456|123456||ERXPP|${{ timestamp }}|userID:192.168.0.1|ZPN|319234|P|2.1||\r" +
+            "ZCA|1|70|04|AR|05|\r" +
+            "ZCB|BC00000I10|140905|319234\r" +
+            "ZCC||||||||||000nnnnnnnnnn|\r" +
+            "ZCD|||N|319234||319234|2063735||100|7|91|nnnnnnnnnn|||||1486||222|||||nnnnnn|912351175\r" +
+            "ZPJ|ZPJ1^^^^^^|ZPJ2^^~ZPJ2^^~ZPJ2^^|ZPJ3^^|ZPJ4^Transaction Trace ID: 319234\r" +
+            "ZZZ|TAC||319234|P1|nnnnnnnnnn|||||ZZZ1^\r" +
+            "ZZZ|TDU||319234|P1|nnnnnnnnnn|||||ZZZ1^\r"
+    },
+    {
         name: "TACTDU_0104_REQUEST-20334 (encrypted)",
         purpose: "Adjudicate a Dispense Claim request message (Encrypted)",
         version: "PNet-R70",

--- a/test/k6/examples/vs1/claim.js
+++ b/test/k6/examples/vs1/claim.js
@@ -42,6 +42,20 @@ export const examples = [
             "ZZZ|TDU||319233|P1|nnnnnnnnnn|||||ZZZ1^\r"
     },
     {
+        name: "TACTDU_04_REQUEST-319234",
+        purpose: "Adjudicate a Dispense Claim adjust, reverse, or resubmit an existing claim",
+        version: "PNet-R70",
+        message:
+            "MSH|^~\\&|123456|123456||ERXPP|${{ timestamp }}|userID:192.168.0.1|ZPN|319234|P|2.1||\r" +
+            "ZCA|1|70|04|AR|05|\r" +
+            "ZCB|BC00000I10|140905|319234\r" +
+            "ZCC||||||||||000nnnnnnnnnn|\r" +
+            "ZCD|||N|319234||319234|2063735||100|7|91|nnnnnnnnnn|||||1486||222|||||nnnnnn|912351175\r" +
+            "ZPJ|ZPJ1^^^^^^|ZPJ2^^~ZPJ2^^~ZPJ2^^|ZPJ3^^|ZPJ4^Transaction Trace ID: 319234\r" +
+            "ZZZ|TAC||319234|P1|nnnnnnnnnn|||||ZZZ1^\r" +
+            "ZZZ|TDU||319234|P1|nnnnnnnnnn|||||ZZZ1^\r"
+    },
+    {
         name: "TACTDU_0104_REQUEST-20334 (encrypted)",
         purpose: "Adjudicate a Dispense Claim request message (Encrypted)",
         version: "PNet-R70",


### PR DESCRIPTION
It has been determined that messages of type TAC/TDU 04 (Adjudicate a Dispense Claim adjust, reverse, or resubmit an existing claim) must be allowed to be processed by the PNet API. Currently validation was preventing this. This change addresses that by:

- Updating the validation config to allow TAC/TDU 04 messages
- Adding test messages for this type of message